### PR TITLE
Added objectSelector to webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid running mutating webhook against it's own pods
+
 ## [0.3.1] - 2022-03-03
 
 ### Fixed

--- a/helm/aws-pod-identity-webhook/templates/MutatingWebhookConfiguration.yaml
+++ b/helm/aws-pod-identity-webhook/templates/MutatingWebhookConfiguration.yaml
@@ -18,6 +18,11 @@ webhooks:
       namespace: {{ .Values.namespace }}
       path: "/mutate"
     caBundle: Cg==
+  objectSelector:
+    matchExpressions:
+      - key: "app.kubernetes.io/name"
+        operator: "NotIn"
+        values: ["{{.Values.name}}"]
   rules:
     - operations: [ "CREATE" ]
       apiGroups: [""]


### PR DESCRIPTION
This PR:

- adds an objectSelector to avoid the webhook being triggered on it's own pods being created

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` is valid.
