### PR TITLE
Added force label support for pods in kube-system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for forcing the webhook to run on pods in kube-system with specific label
+
 ## [0.3.2] - 2022-03-10
 
 ### Fixed

--- a/helm/aws-pod-identity-webhook/templates/MutatingWebhookConfiguration.yaml
+++ b/helm/aws-pod-identity-webhook/templates/MutatingWebhookConfiguration.yaml
@@ -33,4 +33,28 @@ webhooks:
       apiGroups: [""]
       apiVersions: ["v1"]
       resources: ["pods"]
+- name: {{ .Values.name }}.amazonaws.com-kube-system
+  failurePolicy: Ignore
+  admissionReviewVersions: [v1beta1]
+  sideEffects: None
+  clientConfig:
+    service:
+      name: {{ .Values.name }}
+      namespace: {{ .Values.namespace }}
+      path: "/mutate"
+    caBundle: Cg==
+  objectSelector:
+    matchExpressions:
+      - key: "aws-pod-identity.giantswarm.io/force"
+        operator: "Exists"
+  namespaceSelector:
+    matchExpressions:
+      - key: "kubernetes.io/metadata.name"
+        operator: In
+        values: ["kube-system"]
+  rules:
+    - operations: [ "CREATE" ]
+      apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
 ---


### PR DESCRIPTION


This PR:

- adds support for a label that can be applied to pods in kube-system to force the webhook to target them where they would otherwise be ignored

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` is valid.
