### PR TITLE
Update image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change webhook port to `9443`
+- Update image to the latest version `v0.4.0`.
+
 ## [0.8.1] - 2022-05-19
 
 ### Fixed

--- a/helm/aws-pod-identity-webhook/Chart.yaml
+++ b/helm/aws-pod-identity-webhook/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.0.1
+appVersion: 0.4.0
 name: aws-pod-identity-webhook
 description: This webhook is for mutating pods that will require AWS IAM access.
 home: https://github.com/giantswarm/aws-pod-identity-webhook

--- a/helm/aws-pod-identity-webhook/templates/Service.yaml
+++ b/helm/aws-pod-identity-webhook/templates/Service.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
 spec:
   ports:
-  - port: 9443
+  - port: 443
     targetPort: {{ .Values.ports.webhook }}
   selector:
     {{- include "labels.selector" . | nindent 4 }}

--- a/helm/aws-pod-identity-webhook/templates/Service.yaml
+++ b/helm/aws-pod-identity-webhook/templates/Service.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
 spec:
   ports:
-  - port: 443
+  - port: 9443
     targetPort: {{ .Values.ports.webhook }}
   selector:
     {{- include "labels.selector" . | nindent 4 }}

--- a/helm/aws-pod-identity-webhook/values.yaml
+++ b/helm/aws-pod-identity-webhook/values.yaml
@@ -12,11 +12,11 @@ project:
 image:
   registry: quay.io
   name: giantswarm/amazon-eks-pod-identity-webhook
-  tag: v0.3.0
+  tag: v0.4.0
   pullPolicy: IfNotPresent
 
 ports:
-  webhook: 443
+  webhook: 9443
   metrics: 9999
 
 verticalPodAutoscaler:


### PR DESCRIPTION
Updating the image to the latest version
Changing the webhook port to make it work for K8s 1.23
```
W0714 16:38:27.539170       1 client_config.go:552] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0714 16:38:27.549931       1 store.go:63] Fetched secret: kube-system/aws-pod-identity-webhook
I0714 16:38:27.550101       1 main.go:195] Creating server
I0714 16:38:27.550250       1 main.go:215] Listening on :9999 for metrics and healthz
I0714 16:38:27.550359       1 main.go:209] Listening on :443
F0714 16:38:27.550678       1 main.go:211] Error listening: "listen tcp :443: bind: permission denied"
```

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

This PR:

- adds/changes/removes etc

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` is valid.