### PR TITLE
Use regional sts endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use regional sts endpoint by default.
+
 ## [1.0.0] - 2022-11-07
 
 ### Added

--- a/helm/aws-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm/aws-pod-identity-webhook/templates/Deployment.yaml
@@ -31,6 +31,7 @@ spec:
             - --metrics-port={{ .Values.ports.metrics }}
             - --logtostderr
             - --tls-secret={{ .Values.name }}
+            - --sts-regional-endpoint
           ports:
             - name: web
               protocol: TCP


### PR DESCRIPTION
Issue: https://github.com/giantswarm/roadmap/issues/1601

Setting the flag for regional sts endpoint so that the pod identity webhook
will inject an additional ENV.

Assuming an IAM role inside an app will use regional endpoint instead of
the global one

After changing the flag and running `aws-cli sts get-caller-identity --debug`

Cluster in **eu-west-1**:

```
...
2022-11-10 12:17:29,198 - MainThread - urllib3.connectionpool - DEBUG - https://sts.cn-north-1.amazonaws.com.cn:443 "POST / HTTP/1.1" 200 473
...
```

Cluster in **eu-west-1**:
```
...
2022-11-10 12:25:06,119 - MainThread - urllib3.connectionpool - DEBUG - Starting new HTTPS connection (1): sts.eu-west-1.amazonaws.com:443
...
```

Assuming roles are still working without issues.