### PR TITLE
Fixed PDB incorrectly matching Job pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- PodDisruptionBudget incorrectly matching the completed `restarter` Job pod.
+
 ## [1.1.0] - 2022-11-10
 
 ### Changed

--- a/helm/aws-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm/aws-pod-identity-webhook/templates/Deployment.yaml
@@ -1,19 +1,22 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: {{ .Values.name }}
+  name: {{ .Values.name }}-app
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+    component: webhook
 spec:
   replicas: 2
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
+      component: webhook
   template:
     metadata:
       labels:
         {{- include "labels.common" . | nindent 8 }}
+        component: webhook
     spec:
       serviceAccountName: {{ .Values.name }}
       containers:

--- a/helm/aws-pod-identity-webhook/templates/PodDisruptionBudget.yaml
+++ b/helm/aws-pod-identity-webhook/templates/PodDisruptionBudget.yaml
@@ -6,8 +6,9 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
-  maxUnavailable: 1
+  minAvailable: 1
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
+      component: webhook
 ---


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

This PR:

- Fixes PodDisruptionBudget incorrectly matching the completed `restarter` Job pod.

This was incorrectly blocking a node from draining due to incorrectly thinking the `maxUnavailable` was already reached. To be safe, I've also switched to `minAvailable` as it's more correct.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` is valid.
