### PR TITLE
Add Account ID

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -8,3 +8,6 @@ CVE-2019-10743 until=2021-10-17
 # Waiting for more direct dependencies to move away.
 CVE-2022-29153 until=2023-06-25
 CVE-2022-24687 until=2023-06-25
+
+# pkg:golang/k8s.io/apiserver@v0.22.2
+sonatype-2022-6522 until=2023-06-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Updated image to `giantswarm/amazon-eks-pod-identity-webhook-gs:v0.1.0` our custom fork to which adds the aws account id to the service account `role-arn` annotation
+
 ## [1.1.1] - 2022-12-08
 
 ### Fixed

--- a/helm/aws-pod-identity-webhook/values.yaml
+++ b/helm/aws-pod-identity-webhook/values.yaml
@@ -12,7 +12,7 @@ project:
 image:
   registry: quay.io
   name: giantswarm/amazon-eks-pod-identity-webhook-gs
-  tag: 0.1.0
+  tag: v0.1.0
   pullPolicy: IfNotPresent
 
 ports:

--- a/helm/aws-pod-identity-webhook/values.yaml
+++ b/helm/aws-pod-identity-webhook/values.yaml
@@ -12,7 +12,7 @@ project:
 image:
   registry: quay.io
   name: giantswarm/amazon-eks-pod-identity-webhook-gs
-  tag: add-account-id
+  tag: 0.1.0
   pullPolicy: IfNotPresent
 
 ports:

--- a/helm/aws-pod-identity-webhook/values.yaml
+++ b/helm/aws-pod-identity-webhook/values.yaml
@@ -11,8 +11,8 @@ project:
 
 image:
   registry: quay.io
-  name: giantswarm/amazon-eks-pod-identity-webhook
-  tag: v0.4.0
+  name: giantswarm/amazon-eks-pod-identity-webhook-gs
+  tag: add-account-id
   pullPolicy: IfNotPresent
 
 ports:


### PR DESCRIPTION
This PR:
- Switches to the image from our fork of [amazon-eks-pod-identity-webhook](https://github.com/giantswarm/amazon-eks-pod-identity-webhook). This fork automatically adds the account id to the AWS role annotated on a service account.

Towards https://github.com/giantswarm/roadmap/issues/1804
### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` is valid.
