### PR TITLE
Add: choose image based on provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added selecting image image based on provider
+- Added `giantswarm/amazon-eks-pod-identity-webhook-gs:v0.1.0` our custom fork to which adds the aws account id to the service account `role-arn` annotation
+
 ## [1.3.0] - 2023-01-05
 
 - Undo image update to `giantswarm/amazon-eks-pod-identity-webhook-gs:v0.1.0` our custom fork to which adds the aws account id to the service account `role-arn` annotation

--- a/helm/aws-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm/aws-pod-identity-webhook/templates/Deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: {{ .Values.name }}
       containers:
         - name: pod-identity-webhook
-          {{- if eq .Values.provider.kind "capa" }}
+          {{- if eq .Values.provider "capa" }}
           image: "{{ .Values.image.registry }}/{{ .Values.gsImage.name }}:{{ .Values.gsImage.tag }}"
           {{- else }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"

--- a/helm/aws-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm/aws-pod-identity-webhook/templates/Deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: {{ .Values.name }}
       containers:
         - name: pod-identity-webhook
-          {{- if eq .Values.provider "capa" }}
+          {{- if eq .Values.provider.kind "capa" }}
           image: "{{ .Values.image.registry }}/{{ .Values.gsImage.name }}:{{ .Values.gsImage.tag }}"
           {{- else }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"

--- a/helm/aws-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm/aws-pod-identity-webhook/templates/Deployment.yaml
@@ -21,7 +21,11 @@ spec:
       serviceAccountName: {{ .Values.name }}
       containers:
         - name: pod-identity-webhook
+          {{- if eq .Values.provider "capa" }}
+          image: "{{ .Values.image.registry }}/{{ .Values.gsImage.name }}:{{ .Values.gsImage.tag }}"
+          {{- else }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /webhook

--- a/helm/aws-pod-identity-webhook/values.yaml
+++ b/helm/aws-pod-identity-webhook/values.yaml
@@ -23,13 +23,6 @@ gsImage:
   name: giantswarm/amazon-eks-pod-identity-webhook-gs
   tag: v0.1.0
 
-# provider
-# Identifies the cloud provider. This *must*
-# be set. If this is installed as a default app from the default-catalog then this
-# value is set dynamically and will be overridden.
-provider:
-  kind: aws
-
 ports:
   webhook: 9443
   metrics: 9999

--- a/helm/aws-pod-identity-webhook/values.yaml
+++ b/helm/aws-pod-identity-webhook/values.yaml
@@ -23,6 +23,12 @@ gsImage:
   name: giantswarm/amazon-eks-pod-identity-webhook-gs
   tag: v0.1.0
 
+# provider
+# Identifies the cloud provider. This *must*
+# be set. If this is installed as a default app from the default-catalog then this
+# value is set dynamically and will be overridden.
+provider: CHANGEME
+
 ports:
   webhook: 9443
   metrics: 9999

--- a/helm/aws-pod-identity-webhook/values.yaml
+++ b/helm/aws-pod-identity-webhook/values.yaml
@@ -15,6 +15,20 @@ image:
   tag: v0.4.0
   pullPolicy: IfNotPresent
 
+# We currently have two images available to us as we move towards https://github.com/giantswarm/roadmap/issues/1640
+# This will change when we have changes in our fork merged back upstream.
+# We have to support two images for now because the kiam-agent "vintage" clusters on older release versions (< v18.1.0) doesn't allow
+# for the network calls in changes made and this causes the deployment to fail.
+gsImage:
+  name: giantswarm/amazon-eks-pod-identity-webhook-gs
+  tag: v0.1.0
+
+# provider
+# Identifies the cloud provider. This *must*
+# be set. If this is installed as a default app from the default-catalog then this
+# value is set dynamically and will be overridden.
+provider: CHANGEME
+
 ports:
   webhook: 9443
   metrics: 9999

--- a/helm/aws-pod-identity-webhook/values.yaml
+++ b/helm/aws-pod-identity-webhook/values.yaml
@@ -27,7 +27,8 @@ gsImage:
 # Identifies the cloud provider. This *must*
 # be set. If this is installed as a default app from the default-catalog then this
 # value is set dynamically and will be overridden.
-provider: CHANGEME
+provider:
+  kind: aws
 
 ports:
   webhook: 9443


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

This PR:
Adds: the option to choose between images based on the provider

Why?
Release is currently blocked on clusters < `v18.1.0` by `kiam-agent`. 
This causes 
````
caused by: EC2MetadataError: failed to make EC2Metadata request
request blocked by allow-route-regexp "/latest/meta-data/placement/availability-zone": /latest/dynamic/instance-identity/document

	status code: 404,
````
the pod then crash loops and the deployment isn't satisfied.

Towards - https://github.com/giantswarm/roadmap/issues/1804
### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` is valid.
