### PR TITLE
Add the use of runtime default seccomp profile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added the use of the runtime/default seccomp profile.
+
 ## [1.4.0] - 2023-01-12
 
 - Added selecting image image based on provider

--- a/helm/aws-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm/aws-pod-identity-webhook/templates/Deployment.yaml
@@ -19,6 +19,10 @@ spec:
         component: webhook
     spec:
       serviceAccountName: {{ .Values.name }}
+      securityContext:
+        {{- with .Values.podSecurityContext }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}
       containers:
         - name: pod-identity-webhook
           {{- if eq .Values.provider "capa" }}
@@ -46,6 +50,10 @@ spec:
             - name: metrics
               protocol: TCP
               containerPort: {{ .Values.ports.metrics }}
+          securityContext:
+            {{- with .Values.securityContext }}
+              {{- . | toYaml | nindent 10 }}
+            {{- end }}
           volumeMounts:
             - name: cert
               mountPath: "/etc/webhook/certs"

--- a/helm/aws-pod-identity-webhook/templates/PodSecurityPolicy.yaml
+++ b/helm/aws-pod-identity-webhook/templates/PodSecurityPolicy.yaml
@@ -3,6 +3,8 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ .Values.name }}
   namespace: {{ .Values.namespace }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/aws-pod-identity-webhook/values.schema.json
+++ b/helm/aws-pod-identity-webhook/values.schema.json
@@ -1,0 +1,144 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "annotationPrefix": {
+            "type": "string"
+        },
+        "aws": {
+            "type": "object",
+            "properties": {
+                "tokenAudience": {
+                    "type": "string"
+                }
+            }
+        },
+        "gsImage": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "name": {
+            "type": "string"
+        },
+        "namespace": {
+            "type": "string"
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "ports": {
+            "type": "object",
+            "properties": {
+                "metrics": {
+                    "type": "integer"
+                },
+                "webhook": {
+                    "type": "integer"
+                }
+            }
+        },
+        "project": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string"
+                },
+                "commit": {
+                    "type": "string"
+                }
+            }
+        },
+        "provider": {
+            "type": "string"
+        },
+        "restarter": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "registry": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "schedule": {
+                    "type": "string"
+                }
+            }
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "serviceType": {
+            "type": "string"
+        },
+        "verticalPodAutoscaler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        }
+    }
+}

--- a/helm/aws-pod-identity-webhook/values.yaml
+++ b/helm/aws-pod-identity-webhook/values.yaml
@@ -46,3 +46,13 @@ restarter:
     registry: docker.io
     name: giantswarm/aws-pod-identity-restarter
     tag: [[ .Version ]]
+
+# Add seccomp to pod security context
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+# Add seccomp to container security context
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault


### PR DESCRIPTION
I've modified the container and pod securitycontexts to let this application make use of the runtime/default seccomp profile. During testing this did not seem to interrupt any functionality. Please confirm this if possible.
This is done in light of:

https://github.com/giantswarm/roadmap/issues/259

Drop a message on slack if you've got questions.
