### PR TITLE
Update: Bump giantswarm fork image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update image to the latest version of our fork `v0.2.0`.
+
 ## [1.4.0] - 2023-01-12
 
 - Added selecting image image based on provider

--- a/helm/aws-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm/aws-pod-identity-webhook/templates/Deployment.yaml
@@ -39,6 +39,9 @@ spec:
             - --logtostderr
             - --tls-secret={{ .Values.name }}
             - --sts-regional-endpoint
+            {{- if eq .Values.provider "capa" }}
+            - --compose-role-arn
+            {{- end }}
           ports:
             - name: web
               protocol: TCP

--- a/helm/aws-pod-identity-webhook/values.yaml
+++ b/helm/aws-pod-identity-webhook/values.yaml
@@ -21,7 +21,7 @@ image:
 # for the network calls in changes made and this causes the deployment to fail.
 gsImage:
   name: giantswarm/amazon-eks-pod-identity-webhook-gs
-  tag: v0.1.0
+  tag: v0.2.0
 
 # provider
 # Identifies the cloud provider. This *must*


### PR DESCRIPTION
This PR:
This PR bumps the image to the newest version of our fork. This version requires a flag to compose the full IAM ARN is missing. 

Reference: https://github.com/giantswarm/amazon-eks-pod-identity-webhook/pull/2

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` is valid.
