### PR TITLE
Specify `group` in the `Certificate`'s `issuerRef` to avoid renewal issues in certain clusters.

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -11,3 +11,5 @@ CVE-2022-24687 until=2023-06-25
 
 # pkg:golang/k8s.io/apiserver@v0.22.2
 sonatype-2022-6522 until=2023-06-25
+
+CVE-2020-8561

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Specify `group` in the `Certificate`'s `issuerRef` to avoid renewal issues in certain clusters.
+
 ## [1.7.0] - 2023-03-15
 
 ### Changed

--- a/helm/aws-pod-identity-webhook/templates/Certificate.yaml
+++ b/helm/aws-pod-identity-webhook/templates/Certificate.yaml
@@ -14,6 +14,7 @@ spec:
   - "{{ .Values.name }}.{{ .Values.namespace }}.svc.local"
   - "{{ .Values.name }}.{{ .Values.namespace }}.svc.cluster.local"
   issuerRef:
+    group: cert-manager.io
     kind: ClusterIssuer
     name: selfsigned-giantswarm
   secretName: {{ .Values.name }}


### PR DESCRIPTION
See https://gigantic.slack.com/archives/C02GLN41UP2/p1680620256907619

This PR:

- adds the `group` in the `issuerRef` field of the Certificate CR to prevent cert-manager from failing renewing certificates on certain clusters

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` is valid.
