### PR TITLE
Remove duplicated labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove duplicated labels in Helm manifests.
+
 ## [1.8.0] - 2023-04-19
 
 ### Changed

--- a/helm/aws-pod-identity-webhook/templates/_helpers.tpl
+++ b/helm/aws-pod-identity-webhook/templates/_helpers.tpl
@@ -20,8 +20,6 @@ Common labels
 */}}
 {{- define "labels.common" -}}
 {{ include "labels.selector" . }}
-app.kubernetes.io/name: {{ .Values.name }}
-app.kubernetes.io/instance: {{ .Release.Name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2414

Helm fails to install the chart because

```
Helm upgrade failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
        line 10: mapping key "app.kubernetes.io/name" already defined at line 8
        line 11: mapping key "app.kubernetes.io/instance" already defined at line 9
```

### Checklist

- [X] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` is valid.
