### PR TITLE
Fix indentation for seccompProfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix indentation for `seccompProfile` in `Deployment` Helm manifest. 
+
 ## [1.8.1] - 2023-05-01
 
 ### Fixed

--- a/helm/aws-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm/aws-pod-identity-webhook/templates/Deployment.yaml
@@ -55,7 +55,7 @@ spec:
               containerPort: {{ .Values.ports.metrics }}
           securityContext:
             {{- with .Values.securityContext }}
-              {{- . | toYaml | nindent 10 }}
+              {{- . | toYaml | nindent 12 }}
             {{- end }}
           volumeMounts:
             - name: cert


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2414

While trying to install this app chart using Helm I get

```
Helm upgrade failed: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0]):
      unknown field "seccompProfile" in io.k8s.api.core.v1.Container
```

The indentation for the `seccompProfie` was off
```
          securityContext:
          seccompProfile:
            type: RuntimeDefault
```

With this change we get
```
          securityContext:
            seccompProfile:
              type: RuntimeDefault
```

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` is valid.
