### PR TITLE
Make PSP Rendering conditional for 1.25+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make PSP rendering conditional for 1.25+ compatibility
+
 ## [1.11.1] - 2023-07-31
 
 ### Fixed

--- a/helm/aws-pod-identity-webhook/templates/psp.yaml
+++ b/helm/aws-pod-identity-webhook/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -27,3 +28,4 @@ spec:
     rule: MustRunAs
   runAsUser:
     rule: MustRunAsNonRoot
+{{- end }}

--- a/helm/aws-pod-identity-webhook/templates/restarter/psp.yaml
+++ b/helm/aws-pod-identity-webhook/templates/restarter/psp.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.restarter.enabled }}
-{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2533

This PR:

- adds missing `conditional` for psp rendering
- change an existing conditional to `capabilities check`

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` is valid.
