### PR TITLE
In case it's not possible to determine the owner of a pod, log and co…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make PSP rendering conditional for 1.25+ compatibility
 
+### Fixed
+
+- In case it's not possible to determine the owner of a pod, log and continue rather than panic.
+
 ## [1.11.1] - 2023-07-31
 
 ### Fixed

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -104,7 +104,8 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	for _, pod := range pods {
 		owner, err := ownerFinder.FindOwner(ctx, pod)
 		if err != nil {
-			return microerror.Mask(err)
+			r.logger.Debugf(ctx, "error finding owner for pod %s/%s: %s", pod.Namespace, pod.Name, microerror.Cause(err))
+			continue
 		}
 
 		if owner != nil {


### PR DESCRIPTION
…ntinue rather than panic.

towards: https://github.com/giantswarm/giantswarm/issues/28421

This PR:

- fixes a bug where the job would constantly crash when it was not possible to determine what resource owned a pod.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` is valid.
