### PR TITLE
Fix `service`'s selector to not include the restarer job during prome…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - In case it's not possible to determine the owner of a pod, log and continue rather than panic.
+- Fix `service`'s selector to not include the restarer job during prometheus scraping.
 
 ## [1.11.1] - 2023-07-31
 

--- a/helm/aws-pod-identity-webhook/templates/service.yaml
+++ b/helm/aws-pod-identity-webhook/templates/service.yaml
@@ -19,4 +19,5 @@ spec:
     targetPort: {{ .Values.ports.metrics }}
   selector:
     {{- include "labels.selector" . | nindent 4 }}
+    component: webhook
 ---


### PR DESCRIPTION
…theus scraping.

the selector was too broad and selected cronjob pods and not the webhook ones only

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` is valid.
