### PR TITLE
Don't add `use` permission on `PSP` when PSPs are disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't add `use` permission on `PSP` when PSPs are disabled.
+
 ## [1.13.0] - 2023-10-18
 
 ### Added

--- a/helm/aws-pod-identity-webhook/templates/rbac.yaml
+++ b/helm/aws-pod-identity-webhook/templates/rbac.yaml
@@ -24,6 +24,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
 rules:
+{{- if not .Values.global.podSecurityStandards.enforced }}
 - apiGroups:
   - policy
   resourceNames:
@@ -32,6 +33,7 @@ rules:
   - podsecuritypolicies
   verbs:
   - use
+  {{- end }}
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
When PSP is disabled, there is no reason to have the `use` permission set in the cluster role.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` is valid.
