### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [1.13.2] - 2023-10-18
 
 ### Fixed
@@ -74,7 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix indentation for `seccompProfile` in `Deployment` Helm manifest. 
+- Fix indentation for `seccompProfile` in `Deployment` Helm manifest.
 
 ## [1.8.1] - 2023-05-01
 

--- a/helm/aws-pod-identity-webhook/values.yaml
+++ b/helm/aws-pod-identity-webhook/values.yaml
@@ -10,7 +10,7 @@ project:
   commit: "[[ .SHA ]]"
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   name: giantswarm/amazon-eks-pod-identity-webhook
   tag: v0.4.0
   pullPolicy: IfNotPresent
@@ -78,7 +78,7 @@ securityContext:
   readOnlyRootFilesystem: true
   capabilities:
     drop:
-    - ALL
+      - ALL
 
 global:
   podSecurityStandards:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
