### PR TITLE
disallow privilege escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Disallow privilege escalation in restarter.
+
 ## [1.14.0] - 2024-01-15
 
 ### Changed

--- a/helm/aws-pod-identity-webhook/templates/restarter/cronjob.yaml
+++ b/helm/aws-pod-identity-webhook/templates/restarter/cronjob.yaml
@@ -36,6 +36,7 @@ spec:
               {{- toYaml .Values.restarter.resources | nindent 16 }}
               securityContext:
                 readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
           dnsPolicy: ClusterFirst
           restartPolicy: Never
           serviceAccountName:  {{ .Values.name }}-restarter


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

This PR:

PSS breaks with:

```
4m52s       Warning   PolicyViolation     clusterpolicy/disallow-privilege-escalation   (combined from similar events): Job kube-system/aws-pod-identity-webhook-restarter-28422195: [autogen-privilege-escalation] fail; validation error: Privilege escalation is disallowed. The fields spec.containers[*].securityContext.allowPrivilegeEscalation, spec.initContainers[*].securityContext.allowPrivilegeEscalation, and spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation must be set to `false`. rule autogen-privilege-escalation failed at path /spec/template/spec/containers/0/securityContext/allowPrivilegeEscalation/
```

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` is valid.
