### PR TITLE
Fix VPA being ineffective due to referring to a non-existing `Deployment` name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix VPA being ineffective due to referring to a non-existing `Deployment` name
+
 ## [1.16.0] - 2024-06-06
 
 ### Added

--- a/helm/aws-pod-identity-webhook/templates/vpa.yaml
+++ b/helm/aws-pod-identity-webhook/templates/vpa.yaml
@@ -16,7 +16,7 @@ spec:
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name:  {{ .Values.name }}
+    name:  {{ .Values.name }}-app
   updatePolicy:
     updateMode: Auto
 {{ end }}


### PR DESCRIPTION
As noticed on customer cluster

```
E0809 07:14:53.424752       1 cluster_feeder.go:532] Cannot get target selector from VPA's targetRef. Reason: Deployment kube-system/aws-pod-identity-webhook does not exist
```

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` is valid.
