### PR TITLE
Add support for rolling `Deployments` owned by unknown CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add support for rolling `Deployments` owned by unknown CRs, like the case of Crossplane providers.
+
 ## [1.18.0] - 2025-01-27
 
 ### Changed

--- a/pkg/ownerfinder/error.go
+++ b/pkg/ownerfinder/error.go
@@ -5,7 +5,3 @@ import "github.com/giantswarm/microerror"
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
 }
-
-var unsupportedOwnerKindError = &microerror.Error{
-	Kind: "unsupportedOwnerKindError",
-}


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

This PR:

Fixes the OwnerFinder handling of unknown owners, like the Crossplane providers, where their `Deployments` are owned by a `ProviderRevision`, which in turn is owned by a `Provider`. The restarter CronJob was failing on these cases.

Now the restarter will find the "last known" owner in the ownership chain, instead of the top-most one, and try to roll that one.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` is valid.
