### PR TITLE
Use appVersion as default container image for restarter

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,4 +1,5 @@
 replace-chart-version-with-git: true
+replace-app-version-with-git: true
 generate-metadata: true
 chart-dir: ./helm/aws-pod-identity-webhook
 destination: ./build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `io.giantswarm.application.audience: all` annotation to publish the app to the customer Backstage catalog.
 - Migrate chart metadata annotations to `io.giantswarm.application.*` format.
+- Use Helm `appVersion` as the default version for the restarter container image.
 
 ## [2.2.0] - 2026-02-24
 

--- a/helm/aws-pod-identity-webhook/Chart.yaml
+++ b/helm/aws-pod-identity-webhook/Chart.yaml
@@ -6,6 +6,7 @@ home: https://github.com/giantswarm/aws-pod-identity-webhook
 sources:
   - https://github.com/aws/amazon-eks-pod-identity-webhook
 version: 2.2.0
+appVersion: 2.2.0
 annotations:
   config.giantswarm.io/version: 1.x.x
   io.giantswarm.application.audience: all

--- a/helm/aws-pod-identity-webhook/templates/restarter/cronjob.yaml
+++ b/helm/aws-pod-identity-webhook/templates/restarter/cronjob.yaml
@@ -31,7 +31,7 @@ spec:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
           containers:
-            - image: "{{ .Values.image.registry }}/{{ .Values.restarter.image.name }}:{{ default .Chart.Version .Values.restarter.image.tag }}"
+            - image: "{{ .Values.image.registry }}/{{ .Values.restarter.image.name }}:{{ default .Chart.AppVersion .Values.restarter.image.tag }}"
               imagePullPolicy: IfNotPresent
               name: pod-restarter
               resources:


### PR DESCRIPTION
The chart version can contain build metadata (e.g., +1234567) which container registries don't support in image tags. Flux adds that metadata, so we can't use it now that we'll deploy this application using `HelmReleases`.